### PR TITLE
Flashcards That Update

### DIFF
--- a/app/controllers/decks_controller.rb
+++ b/app/controllers/decks_controller.rb
@@ -36,8 +36,8 @@ class DecksController < ApplicationController
   def next_card
     session[:progress] = session[:progress].to_i + 10
     session[:progress] = 0 if session[:progress] > 100
-    unlearned_cards = @deck.cards.where(learned: false)
-    @card = unlearned_cards.order(Arel.sql('RANDOM()')).first
+    @unlearned_cards = @deck.cards.where(learned: false)
+    @card = @unlearned_cards.order(Arel.sql('RANDOM()')).first
 
     learned_cards = @deck.cards.where(learned: true)
     total_cards = @deck.cards.count
@@ -58,6 +58,22 @@ class DecksController < ApplicationController
     # end
   end
 
+  def learn_card
+    @deck = Deck.find(params[:id])
+    @card = Card.find(params[:current_card_id])
+    @card.learned = true
+    if @card.save!
+      redirect_to next_card_deck_path(@deck)
+    end
+  end
+
+  def reset_learned
+    current_user.cards.all.each do |user_card|
+      user_card.learned = false
+      user_card.save!
+    end
+    redirect_to decks_url, notice: "Reset Flashcards"
+  end
 
   private
 

--- a/app/views/decks/index.html.erb
+++ b/app/views/decks/index.html.erb
@@ -57,7 +57,9 @@
 
 </div>
 
-
+<div class="box">
+  <%= link_to 'Reset Flashcards', reset_learned_url %>
+</div>
 <!--
 <div class="container">
 

--- a/app/views/decks/next_card.html.erb
+++ b/app/views/decks/next_card.html.erb
@@ -3,38 +3,76 @@
 <%= render 'partials/title_bar', destination: decks_url, title: title_bar_title %>
 
 <div class="content-wrapper mt-3">
-  <div class="card-container">
-    <div class="flashcard">
-      <div class="card-front card-side">
-        <h1 class="kanji-character"><%= @card.kanji.character %></h1>
+
+  <% if @card.nil? %>
+
+    <div style="height: 70vh;" class="container d-flex flex-column justify-content-center align-items-center">
+
+      <div class="badge fs-2 bg-success">
+        All finished!
       </div>
-      <div class="card-back card-side">
-        <p>Meanings: <%= @card.kanji.meanings.join(', ') %></p>
-        <p>Readings: <%= (@card.kanji.on_readings + @card.kanji.kun_readings).join(', ') %></p>
+
+      <%= button_to decks_url, method: :get, class: "mt-5 btn btn-primary text-white" do%>
+        See all decks
+      <% end %>
+
+    </div>
+
+  <% else %>
+
+    <div class="badge bg-info mb-3 fs-4">
+      <%= "#{@unlearned_cards.count} Cards Remaining" %>
+    </div>
+
+    <div class="card-container">
+      <div class="flashcard">
+        <div class="card-front card-side">
+          <h1 class="kanji-character"><%= @card.kanji.character %></h1>
+        </div>
+        <div class="card-back card-side">
+          <p>Meanings: <%= @card.kanji.meanings.join(', ') %></p>
+          <p>Readings: <%= (@card.kanji.on_readings + @card.kanji.kun_readings).join(', ') %></p>
+        </div>
       </div>
     </div>
-  </div>
-  <div class="progress" style="width: 260px; margin-top: 20px;">
-    <div class="progress-bar" role="progressbar" style="width: <%= session[:progress] || 0 %>%;" aria-valuenow="<%= session[:progress] || 0 %>" aria-valuemin="0" aria-valuemax="100"></div>
-  </div>
-  <br>
-<div class="btn-group" role="group" aria-label="Recall Level Buttons">
-  <div class="btn-margin-right">
-    <%= button_to learn_card_deck_path(@deck), method: :patch, class: 'btn btn-success', params: { current_card_id: @card.id, recall_level: 'easy' } do %>
-      Easy
-    <% end %>
-  </div>
-  <div class="btn-margin-right">
-    <%= button_to learn_card_deck_path(@deck), method: :patch, class: 'btn btn-warning', params: { current_card_id: @card.id, recall_level: 'medium' } do %>
-      Remembered
-    <% end %>
-  </div>
-  <div>
-    <%= button_to learn_card_deck_path(@deck), method: :patch, class: 'btn btn-danger', params: { current_card_id: @card.id, recall_level: 'hard' } do %>
-      Forgot
-    <% end %>
-  </div>
-</div>
+
+<!-- TODO Controller needs to keep track of how many cards have been studied.
+    Maybe use a "learned_count" param.
+
+    <div class="progress" style="width: 260px; margin-top: 20px;">
+      <div  class="progress-bar"
+            role="progressbar"
+            style="width: <%= session[:progress] || 0 %>%;"
+            aria-valuenow="<%= session[:progress] || 0 %>"
+            aria-valuemin="0" aria-valuemax="100">
+
+      </div>
+    </div>
+-->
+    <br>
+
+    <div class="btn-group mt-3" role="group" aria-label="Recall Level Buttons">
+      <div class="btn-margin-right">
+        <%= button_to learn_card_deck_path(@deck), method: :patch, class: 'text-white btn btn-success', params: { current_card_id: @card.id, recall_level: 'easy' } do %>
+          Easy
+        <% end %>
+      </div>
+
+      <div class="btn-margin-right">
+        <%= button_to learn_card_deck_path(@deck), method: :patch, class: 'text-white btn btn-warning', params: { current_card_id: @card.id, recall_level: 'medium' } do %>
+          Remembered
+        <% end %>
+      </div>
+
+      <div>
+        <%= button_to learn_card_deck_path(@deck), method: :patch, class: 'text-white btn btn-danger', params: { current_card_id: @card.id, recall_level: 'hard' } do %>
+          Forgot
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+
+
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   resources :decks do
     member do
       get 'next_card'
-      patch 'learn_card' 
+      patch 'learn_card'
     end
   end
 # adding custom routes to the resources? https://guides.rubyonrails.org/routing.html#adding-more-restful-actions
@@ -26,6 +26,6 @@ Rails.application.routes.draw do
 
   get "capture" => 'cards#capture', as: :capture
   post "capture" => 'cards#new_capture', as: :new_capture
-  # maybe we don't need the line below?
-  post "/new_capture", to: "cards#new_capture"
+
+  get "reset_learned" => "decks#reset_learned", as: :reset_learned
 end


### PR DESCRIPTION
This PR updates the following:
- The flashcard show page / next_card page display the number of remaining cards to study.
- Clicking on the buttons under the card uses a PATCH request to update the "learned" column on a Card instance.
- A congratulatory message is displayed when there are no more cards to study.
- A link on the decks index can be used to reset all the user's cards to unlearned.