### PR TITLE
Navbar Scaling Fixed

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -19,8 +19,10 @@
 }
 
 .navbar-icon {
-  height: 5rem;
-  width: 5rem;
+  height: 15vmin;
+  width: 15vmin;
+  max-height: 10vh;
+  max-width: 10vh;
   fill: url(#default-gradient) #454545;
 }
 


### PR DESCRIPTION
Navbar icons are now sized with the relative unit vmin and capped to a height&width of 10vh