### PR TITLE
Attempt to Fix Unsavable Kanji #2

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -4,7 +4,7 @@ class Card < ApplicationRecord
   has_many :entries, dependent: :destroy
   has_many :decks, through: :entries
 
-  validates :character, presence: true, uniqueness: true
+  validates :character, presence: true, uniqueness: {scope: :user_id, message: "User has already collected this Kanji."}
 
   # disable for now
   # geocoded_by :latitude, :longitude


### PR DESCRIPTION
Save error was likely due to the following problem in the Card model:
- **Card validation was checking for duplicates among ALL Card instances instead of just the current_user's**
