### PR TITLE
Close Camera Stream on Page Close

### DIFF
--- a/app/javascript/controllers/capture_controller.js
+++ b/app/javascript/controllers/capture_controller.js
@@ -55,7 +55,8 @@ export default class extends Controller {
   modalButtonStyle = "camera-modal-button btn btn-primary text-white w-100 rounded-pill shadow-sm m-1";
 
   connect() {
-    console.log("I'm connected");
+
+    this.kanjiField.value = null;
 
     this.setPageStyle();
 
@@ -71,6 +72,11 @@ export default class extends Controller {
       this.getLocation();
     }
 
+  }
+
+  disconnect() {
+    this.kanjiField.value = null;
+    this.stopCamera();
   }
 
   handleDevicePermissions() {
@@ -278,7 +284,13 @@ export default class extends Controller {
   }
 
   stopCamera() {
-    this.videoElement.srcObject = null;
+    if (this.videoElement.srcObject) {
+      const stream = this.videoElement.srcObject;
+      const tracks = stream.getTracks();
+
+      tracks.forEach(track => track.stop());
+      this.videoElement.srcObject = null;
+    }
   }
 
   // +++ Segmentation Modes +++
@@ -317,7 +329,7 @@ export default class extends Controller {
     });
 
     const ret = await worker.recognize(this.canvas.toDataURL("image/png"), "jpn");
-    console.log(ret.data.text);
+    // console.log(ret.data.text);
 
     const recognizedKanji = this.stripKanji(ret.data.text);
 
@@ -414,7 +426,6 @@ export default class extends Controller {
   }
 
   updateTouchPos(event, newTouch=false) {
-    console.log("touch");
     // Example touch event:
     // Touch { identifier: 1815, target: canvas#canvas.full-screen, screenX: 880, screenY: 174, clientX: 712, clientY: 133, pageX: 712, pageY: 133, radiusX: 1, radiusY: 1 }
     if (event.touches[0] === undefined) { return; }
@@ -537,7 +548,7 @@ export default class extends Controller {
       // This needs to happen with an async function.
       this.loadImageFromDataURL(imageDataURL)
         .then((image) => {
-          console.log("Image loaded:", image);
+          // console.log("Image loaded:", image);
           this.captureImage = image;
         })
         .catch((error) => {
@@ -555,11 +566,9 @@ export default class extends Controller {
       this.stopCamera();
 
       const kanjiText = document.querySelector('.selected').innerText;
-      console.log("kanjiText: ", kanjiText);
       // const newDataURL = canvas.toDataURL('image/png'); // Adjust format as needed
       // imageField.value = newDataURL;
       this.kanjiField.value = kanjiText;
-      console.log("kanjiField: ", this.kanjiField);
 
       // submitFormWithImageData();
       if (this.kanjiField !== "") {

--- a/app/javascript/controllers/capture_controller.js
+++ b/app/javascript/controllers/capture_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
 
   captureButton = document.getElementById('capture-button');
   retakeButton = document.getElementById('retake-button');
+  homeButton = document.getElementById('home-button');
 
   alertText = document.getElementById('alert-text');
   errorText = document.getElementById('error-text');
@@ -589,6 +590,11 @@ export default class extends Controller {
       this.clearCanvas();
       this.turnElement("button-bar", "on");
       this.updateAlertText(this.captureInstruction);
+    });
+
+    this.homeButton.addEventListener('mouseup', () => {
+      this.stopCamera();
+      window.location.href = "/dashboard";
     });
 
     // Prevent pull-to-refresh

--- a/app/views/cards/capture.html.erb
+++ b/app/views/cards/capture.html.erb
@@ -37,11 +37,9 @@
   <canvas id="canvas" width="2000" height="480"></canvas>
 </div>
 
-<%# link_to dashboard_path do %>
 <div id="home-button">
   <%= image_tag 'navbar_icons/nav_home.svg', class: "camera-icon" %>
 </div>
-<%# end %>
 
 <div id="retake-button">
   <%= image_tag 'capture_page/refresh_icon.svg', class: "camera-icon" %>

--- a/app/views/cards/capture.html.erb
+++ b/app/views/cards/capture.html.erb
@@ -37,11 +37,11 @@
   <canvas id="canvas" width="2000" height="480"></canvas>
 </div>
 
-<%= link_to dashboard_path do %>
-  <div id="home-button">
-    <%= image_tag 'navbar_icons/nav_home.svg', class: "camera-icon" %>
-  </div>
-<% end %>
+<%# link_to dashboard_path do %>
+<div id="home-button">
+  <%= image_tag 'navbar_icons/nav_home.svg', class: "camera-icon" %>
+</div>
+<%# end %>
 
 <div id="retake-button">
   <%= image_tag 'capture_page/refresh_icon.svg', class: "camera-icon" %>


### PR DESCRIPTION
- **shutdown camera streams from disconnect method**
- **home button on capture page now has a js event listener that shuts down the camera stream and then navigates to the dashboard for more consistent results.**
- **deleted rails link helper on capture erb file**

This update ensures that the camera stream does not remain active while the user is browsing other pages.